### PR TITLE
align depth sim

### DIFF
--- a/docker-ros2/Dockerfile
+++ b/docker-ros2/Dockerfile
@@ -55,6 +55,7 @@ RUN sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.ke
   ros-${ROS_DISTRO}-moveit \
   ros-${ROS_DISTRO}-moveit-py \
   ros-${ROS_DISTRO}-tf-transformations \
+  ros-${ROS_DISTRO}-image-pipeline \
   && rm -rf /var/lib/apt-get/lists/*
   
 # Orbbec driver dependencies

--- a/prl_ur5_gazebo/config/camera_bridge.yaml
+++ b/prl_ur5_gazebo/config/camera_bridge.yaml
@@ -1,120 +1,180 @@
-- ros_topic_name: /alpha_camera/color/image
+- ros_topic_name: camera/alpha_camera/color/image
   gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/alpha_camera_color/image
   ros_type_name: sensor_msgs/msg/Image
   gz_type_name: gz.msgs.Image
   direction: GZ_TO_ROS
-- ros_topic_name: /alpha_camera/color/camera_info
+- ros_topic_name: camera/alpha_camera/color/camera_info
   gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/alpha_camera_color/camera_info
   ros_type_name: sensor_msgs/msg/CameraInfo
   gz_type_name: gz.msgs.CameraInfo
   direction: GZ_TO_ROS
-- ros_topic_name: /alpha_camera/depth/depth_image
+- ros_topic_name: camera/alpha_camera/depth/camera_info
+  gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/alpha_camera_depth/camera_info
+  ros_type_name: sensor_msgs/msg/CameraInfo
+  gz_type_name: gz.msgs.CameraInfo
+  direction: GZ_TO_ROS
+- ros_topic_name: camera/alpha_camera/depth/depth_image
   gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/alpha_camera_depth/depth_image
   ros_type_name: sensor_msgs/msg/Image
   gz_type_name: gz.msgs.Image
   direction: GZ_TO_ROS
-- ros_topic_name: /alpha_camera/depth/depth_image/points
+- ros_topic_name: camera/alpha_camera/depth/depth_image/points
   gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/alpha_camera_depth/depth_image/points
   ros_type_name: sensor_msgs/msg/PointCloud2
   gz_type_name: gz.msgs.PointCloudPacked
   direction: GZ_TO_ROS
-- ros_topic_name: /alpha_camera/ired/ired1/image
+- ros_topic_name: camera/alpha_camera/ired/ired1/image
   gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/alpha_camera_ired1/image
   ros_type_name: sensor_msgs/msg/Image
   gz_type_name: gz.msgs.Image
   direction: GZ_TO_ROS
-- ros_topic_name: /alpha_camera/ired/ired1/camera_info
+- ros_topic_name: camera/alpha_camera/ired/ired1/camera_info
   gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/alpha_camera_ired1/camera_info
   ros_type_name: sensor_msgs/msg/CameraInfo
   gz_type_name: gz.msgs.CameraInfo
   direction: GZ_TO_ROS
-- ros_topic_name: /alpha_camera/ired/ired2/image
+- ros_topic_name: camera/alpha_camera/ired/ired2/image
   gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/alpha_camera_ired2/image
   ros_type_name: sensor_msgs/msg/Image
   gz_type_name: gz.msgs.Image
   direction: GZ_TO_ROS
-- ros_topic_name: /alpha_camera/ired/ired2/camera_info
+- ros_topic_name: camera/alpha_camera/ired/ired2/camera_info
   gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/alpha_camera_ired2/camera_info
   ros_type_name: sensor_msgs/msg/CameraInfo
   gz_type_name: gz.msgs.CameraInfo
   direction: GZ_TO_ROS
-- ros_topic_name: /bravo_camera/color/image
+- ros_topic_name: camera/bravo_camera/color/image
   gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/bravo_camera_color/image
   ros_type_name: sensor_msgs/msg/Image
   gz_type_name: gz.msgs.Image
   direction: GZ_TO_ROS
-- ros_topic_name: /bravo_camera/color/camera_info
+- ros_topic_name: camera/bravo_camera/color/camera_info
   gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/bravo_camera_color/camera_info
   ros_type_name: sensor_msgs/msg/CameraInfo
   gz_type_name: gz.msgs.CameraInfo
   direction: GZ_TO_ROS
-- ros_topic_name: /bravo_camera/depth/depth_image
+- ros_topic_name: camera/bravo_camera/depth/camera_info
+  gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/bravo_camera_depth/camera_info
+  ros_type_name: sensor_msgs/msg/CameraInfo
+  gz_type_name: gz.msgs.CameraInfo
+  direction: GZ_TO_ROS
+- ros_topic_name: camera/bravo_camera/depth/depth_image
   gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/bravo_camera_depth/depth_image
   ros_type_name: sensor_msgs/msg/Image
   gz_type_name: gz.msgs.Image
   direction: GZ_TO_ROS
-- ros_topic_name: /bravo_camera/depth/depth_image/points
+- ros_topic_name: camera/bravo_camera/depth/depth_image/points
   gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/bravo_camera_depth/depth_image/points
   ros_type_name: sensor_msgs/msg/PointCloud2
   gz_type_name: gz.msgs.PointCloudPacked
   direction: GZ_TO_ROS
-- ros_topic_name: /bravo_camera/ired/ired1/image
+- ros_topic_name: camera/bravo_camera/ired/ired1/image
   gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/bravo_camera_ired1/image
   ros_type_name: sensor_msgs/msg/Image
   gz_type_name: gz.msgs.Image
   direction: GZ_TO_ROS
-- ros_topic_name: /bravo_camera/ired/ired1/camera_info
+- ros_topic_name: camera/bravo_camera/ired/ired1/camera_info
   gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/bravo_camera_ired1/camera_info
   ros_type_name: sensor_msgs/msg/CameraInfo
   gz_type_name: gz.msgs.CameraInfo
   direction: GZ_TO_ROS
-- ros_topic_name: /bravo_camera/ired/ired2/image
+- ros_topic_name: camera/bravo_camera/ired/ired2/image
   gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/bravo_camera_ired2/image
   ros_type_name: sensor_msgs/msg/Image
   gz_type_name: gz.msgs.Image
   direction: GZ_TO_ROS
-- ros_topic_name: /bravo_camera/ired/ired2/camera_info
+- ros_topic_name: camera/bravo_camera/ired/ired2/camera_info
   gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/bravo_camera_ired2/camera_info
   ros_type_name: sensor_msgs/msg/CameraInfo
   gz_type_name: gz.msgs.CameraInfo
   direction: GZ_TO_ROS
-- ros_topic_name: /charlie_camera/color/image
+- ros_topic_name: camera/charlie_camera/color/image
   gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/charlie_camera_color/image
   ros_type_name: sensor_msgs/msg/Image
   gz_type_name: gz.msgs.Image
   direction: GZ_TO_ROS
-- ros_topic_name: /charlie_camera/color/camera_info
+- ros_topic_name: camera/charlie_camera/color/camera_info
   gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/charlie_camera_color/camera_info
   ros_type_name: sensor_msgs/msg/CameraInfo
   gz_type_name: gz.msgs.CameraInfo
   direction: GZ_TO_ROS
-- ros_topic_name: /charlie_camera/depth/depth_image
+- ros_topic_name: camera/charlie_camera/depth/camera_info
+  gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/charlie_camera_depth/camera_info
+  ros_type_name: sensor_msgs/msg/CameraInfo
+  gz_type_name: gz.msgs.CameraInfo
+  direction: GZ_TO_ROS
+- ros_topic_name: camera/charlie_camera/depth/depth_image
   gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/charlie_camera_depth/depth_image
   ros_type_name: sensor_msgs/msg/Image
   gz_type_name: gz.msgs.Image
   direction: GZ_TO_ROS
-- ros_topic_name: /charlie_camera/depth/depth_image/points
+- ros_topic_name: camera/charlie_camera/depth/depth_image/points
   gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/charlie_camera_depth/depth_image/points
   ros_type_name: sensor_msgs/msg/PointCloud2
   gz_type_name: gz.msgs.PointCloudPacked
   direction: GZ_TO_ROS
-- ros_topic_name: /charlie_camera/ired/ired1/image
+- ros_topic_name: camera/charlie_camera/ired/ired1/image
   gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/charlie_camera_ired1/image
   ros_type_name: sensor_msgs/msg/Image
   gz_type_name: gz.msgs.Image
   direction: GZ_TO_ROS
-- ros_topic_name: /charlie_camera/ired/ired1/camera_info
+- ros_topic_name: camera/charlie_camera/ired/ired1/camera_info
   gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/charlie_camera_ired1/camera_info
   ros_type_name: sensor_msgs/msg/CameraInfo
   gz_type_name: gz.msgs.CameraInfo
   direction: GZ_TO_ROS
-- ros_topic_name: /charlie_camera/ired/ired2/image
+- ros_topic_name: camera/charlie_camera/ired/ired2/image
   gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/charlie_camera_ired2/image
   ros_type_name: sensor_msgs/msg/Image
   gz_type_name: gz.msgs.Image
   direction: GZ_TO_ROS
-- ros_topic_name: /charlie_camera/ired/ired2/camera_info
+- ros_topic_name: camera/charlie_camera/ired/ired2/camera_info
   gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/charlie_camera_ired2/camera_info
+  ros_type_name: sensor_msgs/msg/CameraInfo
+  gz_type_name: gz.msgs.CameraInfo
+  direction: GZ_TO_ROS
+- ros_topic_name: camera/delta_camera/color/image
+  gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/delta_camera_color/image
+  ros_type_name: sensor_msgs/msg/Image
+  gz_type_name: gz.msgs.Image
+  direction: GZ_TO_ROS
+- ros_topic_name: camera/delta_camera/color/camera_info
+  gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/delta_camera_color/camera_info
+  ros_type_name: sensor_msgs/msg/CameraInfo
+  gz_type_name: gz.msgs.CameraInfo
+  direction: GZ_TO_ROS
+- ros_topic_name: camera/delta_camera/depth/camera_info
+  gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/delta_camera_depth/camera_info
+  ros_type_name: sensor_msgs/msg/CameraInfo
+  gz_type_name: gz.msgs.CameraInfo
+  direction: GZ_TO_ROS
+- ros_topic_name: camera/delta_camera/depth/depth_image
+  gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/delta_camera_depth/depth_image
+  ros_type_name: sensor_msgs/msg/Image
+  gz_type_name: gz.msgs.Image
+  direction: GZ_TO_ROS
+- ros_topic_name: camera/delta_camera/depth/depth_image/points
+  gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/delta_camera_depth/depth_image/points
+  ros_type_name: sensor_msgs/msg/PointCloud2
+  gz_type_name: gz.msgs.PointCloudPacked
+  direction: GZ_TO_ROS
+- ros_topic_name: camera/delta_camera/ired/ired1/image
+  gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/delta_camera_ired1/image
+  ros_type_name: sensor_msgs/msg/Image
+  gz_type_name: gz.msgs.Image
+  direction: GZ_TO_ROS
+- ros_topic_name: camera/delta_camera/ired/ired1/camera_info
+  gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/delta_camera_ired1/camera_info
+  ros_type_name: sensor_msgs/msg/CameraInfo
+  gz_type_name: gz.msgs.CameraInfo
+  direction: GZ_TO_ROS
+- ros_topic_name: camera/delta_camera/ired/ired2/image
+  gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/delta_camera_ired2/image
+  ros_type_name: sensor_msgs/msg/Image
+  gz_type_name: gz.msgs.Image
+  direction: GZ_TO_ROS
+- ros_topic_name: camera/delta_camera/ired/ired2/camera_info
+  gz_topic_name: /world/mantis_world/model/mantis/link/base_link/sensor/delta_camera_ired2/camera_info
   ros_type_name: sensor_msgs/msg/CameraInfo
   gz_type_name: gz.msgs.CameraInfo
   direction: GZ_TO_ROS

--- a/prl_ur5_gazebo/launch/align_depth.launch.py
+++ b/prl_ur5_gazebo/launch/align_depth.launch.py
@@ -1,0 +1,69 @@
+import os
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, RegisterEventHandler, OpaqueFunction
+from launch.event_handlers import OnProcessExit
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import (
+    Command,
+    FindExecutable,
+    LaunchConfiguration,
+    PathJoinSubstitution,
+    IfElseSubstitution,
+)
+from launch_ros.substitutions import FindPackageShare
+from launch.conditions import IfCondition
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+import yaml
+from pathlib import Path
+
+def launch_setup(context):
+    config_file = Path(LaunchConfiguration('camera_config').perform(context))
+    
+    with config_file.open('r') as setup_file:
+        config = yaml.safe_load(setup_file)
+
+    cameras = config.get('cameras', {})
+    camera_align = []
+    for camera_name, camera_info in cameras.items():
+        activate = camera_info.get('activate', False)
+        if activate:
+            enable_align_depth = camera_info.get('align_depth', False)
+            print(f"Camera {camera_name} alignment enabled: {enable_align_depth}")
+            if enable_align_depth:
+                ros_color_info_topic = f'camera/{camera_name}/color/camera_info'
+                ros_depth_info_topic = f'camera/{camera_name}/depth/camera_info'
+                ros_depth_image_topic = f'camera/{camera_name}/depth/depth_image'
+                output_topic = f'camera/{camera_name}/aligned_depth_to_color/image_raw'
+                camera_align.append(
+                    Node(
+                        package='depth_image_proc',
+                        executable='register_node', 
+                        name=f'depth_image_proc_register_{camera_name}',
+                        parameters=[{'use_sim_time': True}],
+                        remappings=[
+                            ('rgb/camera_info', ros_color_info_topic),
+                            ('depth/camera_info', ros_depth_info_topic),
+                            ('depth/image_rect', ros_depth_image_topic),
+                            ('depth_registered/image_rect', output_topic)
+                        ]
+                    )
+                )
+
+    return camera_align
+
+def generate_launch_description():
+    declared_arguments = []
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            'camera_config',
+            default_value=PathJoinSubstitution([
+                FindPackageShare('prl_ur5_robot_configuration'),
+                'config/fixed_cameras',
+                'cameras_config.yaml'
+            ]),
+            description='Path to the camera configuration file.'
+        )
+    )
+    return LaunchDescription(declared_arguments + [OpaqueFunction(function=launch_setup)])

--- a/prl_ur5_gazebo/launch/start_gazebo_sim.launch.py
+++ b/prl_ur5_gazebo/launch/start_gazebo_sim.launch.py
@@ -152,6 +152,16 @@ def launch_setup(context):
         output='screen',
         condition=IfCondition(LaunchConfiguration('activate_cameras')),
     )
+    align_depth = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([
+            PathJoinSubstitution([
+                FindPackageShare("prl_ur5_gazebo"),
+                'launch',
+                'align_depth.launch.py'
+                ]),
+            ]),
+        condition=IfCondition(LaunchConfiguration('activate_cameras')),
+    )
 
     ###### Controllers ######
 
@@ -211,6 +221,7 @@ def launch_setup(context):
                         left_gripper_controller,
                         right_gripper_controller,
                         camera_bridge,
+                        align_depth,
                             ],
                 )
             ),

--- a/prl_ur5_gazebo/scripts/generate_cameras_bridge.py
+++ b/prl_ur5_gazebo/scripts/generate_cameras_bridge.py
@@ -40,14 +40,14 @@ def generate_camera_bridge_config(config_filepath, output_filepath):
             if camera_info.get('enable_color'):
                 print("  - Color camera enabled ")
                 all_topics.append({
-                    'ros_topic_name': f'/{camera_name}/color/image',
+                    'ros_topic_name': f'camera/{camera_name}/color/image',
                     'gz_topic_name': f'{base_gz_path}{camera_name}_color/image',
                     'ros_type_name': 'sensor_msgs/msg/Image',
                     'gz_type_name': 'gz.msgs.Image',
                     'direction': 'GZ_TO_ROS'
                 })
                 all_topics.append({
-                    'ros_topic_name': f'/{camera_name}/color/camera_info',
+                    'ros_topic_name': f'camera/{camera_name}/color/camera_info',
                     'gz_topic_name': f'{base_gz_path}{camera_name}_color/camera_info',
                     'ros_type_name': 'sensor_msgs/msg/CameraInfo',
                     'gz_type_name': 'gz.msgs.CameraInfo',
@@ -58,7 +58,14 @@ def generate_camera_bridge_config(config_filepath, output_filepath):
             if camera_info.get('enable_depth'):
                 print("  - Depth camera enabled ")
                 all_topics.append({
-                    'ros_topic_name': f'/{camera_name}/depth/depth_image',
+                    'ros_topic_name': f'camera/{camera_name}/depth/camera_info',
+                    'gz_topic_name': f'{base_gz_path}{camera_name}_depth/camera_info',
+                    'ros_type_name': 'sensor_msgs/msg/CameraInfo',
+                    'gz_type_name': 'gz.msgs.CameraInfo',
+                    'direction': 'GZ_TO_ROS'
+                })
+                all_topics.append({
+                    'ros_topic_name': f'camera/{camera_name}/depth/depth_image',
                     'gz_topic_name': f'{base_gz_path}{camera_name}_depth/depth_image',
                     'ros_type_name': 'sensor_msgs/msg/Image',
                     'gz_type_name': 'gz.msgs.Image',
@@ -69,7 +76,7 @@ def generate_camera_bridge_config(config_filepath, output_filepath):
             if camera_info.get('pointcloud'):
                 print("  - Pointcloud enabled ")
                 all_topics.append({
-                    'ros_topic_name': f'/{camera_name}/depth/depth_image/points',
+                    'ros_topic_name': f'camera/{camera_name}/depth/depth_image/points',
                     'gz_topic_name': f'{base_gz_path}{camera_name}_depth/depth_image/points',
                     'ros_type_name': 'sensor_msgs/msg/PointCloud2',
                     'gz_type_name': 'gz.msgs.PointCloudPacked',
@@ -82,14 +89,14 @@ def generate_camera_bridge_config(config_filepath, output_filepath):
                 if camera_info.get('enable_infra1'):
                     print("    - Infrared camera 1 enabled ")
                     all_topics.append({
-                        'ros_topic_name': f'/{camera_name}/ired/ired1/image',
+                        'ros_topic_name': f'camera/{camera_name}/ired/ired1/image',
                         'gz_topic_name': f'{base_gz_path}{camera_name}_ired1/image',
                         'ros_type_name': 'sensor_msgs/msg/Image',
                         'gz_type_name': 'gz.msgs.Image',
                         'direction': 'GZ_TO_ROS'
                     })
                     all_topics.append({
-                        'ros_topic_name': f'/{camera_name}/ired/ired1/camera_info',
+                        'ros_topic_name': f'camera/{camera_name}/ired/ired1/camera_info',
                         'gz_topic_name': f'{base_gz_path}{camera_name}_ired1/camera_info',
                         'ros_type_name': 'sensor_msgs/msg/CameraInfo',
                         'gz_type_name': 'gz.msgs.CameraInfo',
@@ -98,14 +105,14 @@ def generate_camera_bridge_config(config_filepath, output_filepath):
                 if camera_info.get('enable_infra2'):
                     print("    - Infrared camera 2 enabled ")
                     all_topics.append({
-                        'ros_topic_name': f'/{camera_name}/ired/ired2/image',
+                        'ros_topic_name': f'camera/{camera_name}/ired/ired2/image',
                         'gz_topic_name': f'{base_gz_path}{camera_name}_ired2/image',
                         'ros_type_name': 'sensor_msgs/msg/Image',
                         'gz_type_name': 'gz.msgs.Image',
                         'direction': 'GZ_TO_ROS'
                     })
                     all_topics.append({
-                        'ros_topic_name': f'/{camera_name}/ired/ired2/camera_info',
+                        'ros_topic_name': f'camera/{camera_name}/ired/ired2/camera_info',
                         'gz_topic_name': f'{base_gz_path}{camera_name}_ired2/camera_info',
                         'ros_type_name': 'sensor_msgs/msg/CameraInfo',
                         'gz_type_name': 'gz.msgs.CameraInfo',


### PR DESCRIPTION
This pull request add a new launch file for aligning depth images, and integrates this functionality into the Gazebo simulation launch process. The changes improve topic organization, add support for depth alignment.

### Camera topic reorganization:
* Updated `ros_topic_name` in `prl_ur5_gazebo/config/camera_bridge.yaml` to include a `camera/` prefix to match with real topics name. This change applies to all camera types (color, depth, infrared, and pointcloud) across multiple cameras (`alpha`, `bravo`, `charlie`, `delta`).
* Updated the `generate_camera_bridge_config` function in `prl_ur5_gazebo/scripts/generate_cameras_bridge.py` to use the new `camera/` namespace for generated topics. 

### New depth alignment feature:
* Added a new launch file `prl_ur5_gazebo/launch/align_depth.launch.py` to enable depth image alignment to color images for cameras with `align_depth` enabled in their configuration.

### Integration into Gazebo simulation:
* Integrated the new `align_depth.launch.py` into the Gazebo simulation launch process