### PR TITLE
add waiting joint_states

### DIFF
--- a/prl_ur5_moveit/CMakeLists.txt
+++ b/prl_ur5_moveit/CMakeLists.txt
@@ -2,11 +2,18 @@ cmake_minimum_required(VERSION 3.22)
 project(prl_ur5_moveit)
 
 find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(sensor_msgs REQUIRED)
 
-ament_package()
+add_executable(wait_for_joint_states src/wait_for_joint_states.cpp)
+ament_target_dependencies(wait_for_joint_states rclcpp sensor_msgs)
+
+install(TARGETS wait_for_joint_states DESTINATION lib/${PROJECT_NAME})
 
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/launch")
     install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 endif()
 
 install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
+
+ament_package()

--- a/prl_ur5_moveit/launch/start_moveit.launch.py
+++ b/prl_ur5_moveit/launch/start_moveit.launch.py
@@ -80,17 +80,17 @@ def launch_setup(context):
         ],
     )
 
-    wait_robot_description = Node(
-        package="ur_robot_driver",
-        executable="wait_for_robot_description",
+    wait_for_joint_states = Node(
+        package="prl_ur5_moveit",
+        executable="wait_for_joint_states",
         output="screen",
     )
 
     return [
-        wait_robot_description,
+        wait_for_joint_states,
         RegisterEventHandler(
             event_handler=OnProcessExit(
-            target_action=wait_robot_description,
+            target_action=wait_for_joint_states,
             on_exit=[
                     node_move_group,
                     rviz_node,

--- a/prl_ur5_moveit/src/wait_for_joint_states.cpp
+++ b/prl_ur5_moveit/src/wait_for_joint_states.cpp
@@ -1,0 +1,49 @@
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/joint_state.hpp"
+
+using namespace std::chrono_literals;
+
+class WaitForJointStates : public rclcpp::Node {
+public:
+  WaitForJointStates() : Node("wait_for_joint_states"), received_(false) {
+    RCLCPP_INFO(this->get_logger(), "Waiting for /joint_states topic...");
+    subscription_ = this->create_subscription<sensor_msgs::msg::JointState>(
+        "/joint_states", 10,
+        std::bind(&WaitForJointStates::jointStateCallback, this,
+                  std::placeholders::_1));
+  }
+
+  bool received() const { return received_; }
+
+private:
+  void jointStateCallback(const sensor_msgs::msg::JointState::SharedPtr msg) {
+    if (!msg->name.empty()) {
+      RCLCPP_INFO(this->get_logger(), "Received first /joint_states message.");
+      received_ = true;
+    }
+  }
+
+  rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr subscription_;
+  bool received_;
+};
+
+int main(int argc, char *argv[]) {
+  rclcpp::init(argc, argv);
+
+  auto node = std::make_shared<WaitForJointStates>();
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(node);
+
+  while (rclcpp::ok() && !node->received()) {
+    exec.spin_some();
+    std::this_thread::sleep_for(50ms);
+  }
+
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
This pull request introduces a new node to the `prl_ur5_moveit` package that waits for the first `/joint_states` message before proceeding with the rest of the MoveIt launch sequence. The main changes involve adding the `wait_for_joint_states` executable, updating the launch file to use it, and implementing its logic in C++. These changes improve synchronization and reliability during robot initialization.
